### PR TITLE
add a link for scala 3 dotty

### DIFF
--- a/3.md
+++ b/3.md
@@ -1,0 +1,4 @@
+---
+title: Scala 3
+redirect_to: https://dotty.epfl.ch/
+---


### PR DESCRIPTION
pointing to dotty for now. We can update accordingly on release.