### PR TITLE
make sca.la/cli point to doc site not install script

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -1,4 +1,4 @@
 ---
 title: scala-cli
-redirect_to: https://virtuslab.github.io/scala-cli-packages/scala-setup.sh
+redirect_to: https://scala-cli.virtuslab.org
 ---


### PR DESCRIPTION
@MasseGuillaume or perhaps there was some motivation for doing it the original way that I'm failing to grasp...?